### PR TITLE
Delay Trace: hop count = -1 and no full hop count

### DIFF
--- a/apps/cdn-ip-app.h
+++ b/apps/cdn-ip-app.h
@@ -73,7 +73,7 @@ public:
   SetProducers(std::string prefixes);
 
 
-  void
+  vector<NameComponents>::size_type
   ChangeProducer();
 
   std::string


### PR DESCRIPTION
In current implementation,
1. If you get a hop count = -1 from delay trace, it means Interest is Nacked on the way.
2. Even for FullDelay record, the hop count means the cost of last transmission, but not the whole Interest-Data process.
