### PR TITLE
model: Fixing warning in ndn-wire.cc

### DIFF
--- a/model/wire/ndn-wire.cc
+++ b/model/wire/ndn-wire.cc
@@ -94,6 +94,7 @@ Wire::ToInterest (Ptr<Packet> packet, int8_t wireFormat/* = WIRE_FORMAT_AUTODETE
           NS_FATAL_ERROR ("Unknown NDN header");
           return 0;
         }
+        return 0;
     }
   else
     {
@@ -157,6 +158,7 @@ Wire::ToData (Ptr<Packet> packet, int8_t wireFormat/* = WIRE_FORMAT_AUTODETECT*/
           NS_FATAL_ERROR ("Unknown NDN header");
           return 0;
         }
+        return 0;
     }
   else
     {


### PR DESCRIPTION
I found and fixed another warning in model/wire/ndn-wire.cc. 
