### PR TITLE
Fix route calculation for shared channel

### DIFF
--- a/helper/ndn-global-routing-helper.cc
+++ b/helper/ndn-global-routing-helper.cc
@@ -133,7 +133,7 @@ GlobalRoutingHelper::Install (Ptr<Node> node)
 	    }
 	  grChannel = ch->GetObject<GlobalRouter> ();
 
-	  gr->AddIncidency (0, grChannel);
+	  gr->AddIncidency (face, grChannel);
 	}
     }
 }


### PR DESCRIPTION
While developing a scenario with an Access Point and some WiFi stations with BestRoute forwarding strategy, I noticed that the GlobalRoutingHelper was not keeping track of those routes involving the common channel links, making prefixes announced by the WiFi stations unreachable.

By making this modification the Routing Calculations started to work as expected for shared channels.
