### PR TITLE
Include in Data packet timestamp field the actual time it was created.

### DIFF
--- a/apps/ndn-producer.cc
+++ b/apps/ndn-producer.cc
@@ -132,6 +132,7 @@ Producer::OnInterest (Ptr<const Interest> interest)
   dataName->append (m_postfix);
   data->SetName (dataName);
   data->SetFreshness (m_freshness);
+  data->SetTimestamp (Simulator::Now());
 
   data->SetSignature (m_signature);
   if (m_keyLocator.size () > 0)


### PR DESCRIPTION
I noticed that when using GetTimestamp() on a Data packet, I always got 0s. Introducing this line and including the actual time the packet was created allows, by using GetTimestamp(), to better analyse at any point of the simulation when a particular Data packet was created.
