### PR TITLE
possible typo in python simple example

### DIFF
--- a/examples/ndn-simple.py
+++ b/examples/ndn-simple.py
@@ -47,7 +47,7 @@ from ns.ndnSIM import *
 # Set default parameters for PointToPoint links and channels
 Config.SetDefault("ns3::PointToPointNetDevice::DataRate", StringValue("10Mbps"))
 Config.SetDefault("ns3::PointToPointChannel::Delay", StringValue("10ms"))
-Config::SetDefault("ns3::QueueBase::MaxPackets", UintegerValue(20))
+Config.SetDefault("ns3::QueueBase::MaxPackets", UintegerValue(20))
 
 # Read optional command-line parameters (e.g., enable visualizer with ./waf --pyrun=<> --visualize
 import sys; cmd = CommandLine(); cmd.Parse(sys.argv);


### PR DESCRIPTION
Hi,

running with

```
NS_LOG=ndn.Consumer:ndn.Producer ./waf --pyrun=src/ndnSIM/examples/ndn-simple.py
```

now it works.


Was giving a syntax error:

```
  File "ndn-simple.py", line 50
    Config::SetDefault("ns3::QueueBase::MaxPackets", UintegerValue(20))
           ^
SyntaxError: invalid syntax
```