### PR TITLE
Use a single source of truth for InFlight calculation

### DIFF
--- a/apps/ndn-consumer-pcon.cpp
+++ b/apps/ndn-consumer-pcon.cpp
@@ -126,9 +126,7 @@ ConsumerPcon::OnData(shared_ptr<const Data> data)
     WindowIncrease();
   }
 
-  if (m_inFlight > static_cast<uint32_t>(0)) {
-    m_inFlight--;
-  }
+  m_inFlight = m_seqTimeouts.size();
 
   NS_LOG_DEBUG("Window: " << m_window << ", InFlight: " << m_inFlight);
 
@@ -140,9 +138,7 @@ ConsumerPcon::OnTimeout(uint32_t sequenceNum)
 {
   WindowDecrease();
 
-  if (m_inFlight > static_cast<uint32_t>(0)) {
-    m_inFlight--;
-  }
+  m_inFlight = m_seqTimeouts.size();
 
   NS_LOG_DEBUG("Window: " << m_window << ", InFlight: " << m_inFlight);
 

--- a/apps/ndn-consumer-window.cpp
+++ b/apps/ndn-consumer-window.cpp
@@ -199,8 +199,7 @@ ConsumerWindow::OnData(shared_ptr<const Data> contentObject)
 void
 ConsumerWindow::OnTimeout(uint32_t sequenceNumber)
 {
-  if (m_inFlight > static_cast<uint32_t>(0))
-    m_inFlight--;
+  m_inFlight = m_seqTimeouts.size();
 
   if (m_setInitialWindowOnTimeout) {
     // m_window = std::max<uint32_t> (0, m_window - 1);
@@ -214,8 +213,8 @@ ConsumerWindow::OnTimeout(uint32_t sequenceNumber)
 void
 ConsumerWindow::WillSendOutInterest(uint32_t sequenceNumber)
 {
-  m_inFlight++;
   Consumer::WillSendOutInterest(sequenceNumber);
+  m_inFlight = m_seqTimeouts.size();
 }
 
 } // namespace ndn


### PR DESCRIPTION
ndn-consumer-window and ndn-consumer-pcon use a simple count for
updating the number of InFlight packets. This works fines as long as no
packet arrives after its timeout has fired. In this case `m_inFlight` is
decreased twice. Ultimately the counter (wrongly) reaches 0 and prevents
proper working of the window algorithm.

This fix does away with the manual calculation of the counter and replaces
it with the size of the `m_seqTimeouts` set.

Signed-off-by: Miguel Rodríguez Pérez <miguel@det.uvigo.gal>